### PR TITLE
fixed bug with face no. 0 in color implementation

### DIFF
--- a/examples/occ_to_off.py
+++ b/examples/occ_to_off.py
@@ -150,6 +150,9 @@ class Mesh:
         xx, yy, zz = np.where(volume > 0.5)
         face_ids = volume[:][np.where(volume > 0.5)]
         face_ids = face_ids.astype('int32')
+        if type(colorarray) != None.__class__:
+            num_faces = len(colorarray) #number of inital mesh faces should be equal to the color array length
+            face_ids[face_ids == num_faces] = 0 #set changed face 0 back to zero
 
         for i in range(len(xx)):
             v000 = (yy[i], xx[i], zz[i])                # 0

--- a/main.cpp
+++ b/main.cpp
@@ -456,6 +456,10 @@ public:
 
           bool overlap = triangle_box_intersection(min, max, v1, v2, v3);
           if (overlap) {
+            if (f == 0){ // since 0 are treated as not voxelized space, need to deal with face index 0
+              occ(h, w, d) = num_faces(); // face 0 has now a new face no. that needs to be taken into account when converting back to off
+              break;
+            } 
             occ(h, w, d) = f;
             break;
           }


### PR DESCRIPTION
When using color flag, face index is used for occupancy (instead of 0s and 1s) and therefore a face with index 0 would be treated as empty voxel.
Now face with index 0 is changed to have a new index in main.cpp, which then is converted back to 0 when needed in occ_to_off.py